### PR TITLE
ec - modified API endpoints to get classrooms for a building

### DIFF
--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -181,7 +181,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
   test("renders without crashing when fallback values are used", async () => {
     axiosMock.onGet("/api/systemInfo").reply(200, {
       springH2ConsoleEnabled: false,
-      showSwaggerUILink: true,
+      showSwaggerUILink: false,
       startQtrYYYYQ: null, // use fallback value
       endQtrYYYYQ: null, // use fallback value
     });

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -32,9 +32,13 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock.onGet("/api/systemInfo").reply(200, {
       ...systemInfoFixtures.showingNeither,
-      startQtrYYYYQ: "20201",
-      endQtrYYYYQ: "20214",
+      QtrYYYQ: "20201",
     });
+    axiosMock.onGet("/api/public/basicQuarterDates").reply(200, [
+      { yyyyq: "20201" },
+      { yyyyq: "20211" },
+      { yyyyq: "20222" },
+    ]);
 
     toast.mockReturnValue({
       addToast: addToast,
@@ -51,7 +55,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     );
   });
 
-  test("when I select a start quarter, the state for start quarter changes", () => {
+  test("when I select a quarter, the state for quarter changes", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -59,22 +63,9 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    userEvent.selectOptions(selectStartQuarter, "20201");
-    expect(selectStartQuarter.value).toBe("20201");
-  });
-
-  test("when I select an end quarter, the state for end quarter changes", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CourseOverTimeBuildingsSearchForm />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-    const selectEndQuarter = screen.getByLabelText("End Quarter");
-    userEvent.selectOptions(selectEndQuarter, "20204");
-    expect(selectEndQuarter.value).toBe("20204");
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20201");
+    expect(selectQuarter.value).toBe("20201");
   });
 
   test("when I select a building, the state for building changes", async () => {
@@ -115,20 +106,17 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     );
 
     const expectedFields = {
-      startQuarter: "20211",
-      endQuarter: "20214",
+      Quarter: "20201",
       buildingCode: "GIRV",
     };
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
     );
 
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    userEvent.selectOptions(selectStartQuarter, "20211");
-    const selectEndQuarter = screen.getByLabelText("End Quarter");
-    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20201");
     const selectBuilding = screen.getByLabelText("Building Name");
     expect(selectBuilding).toBeInTheDocument();
     userEvent.selectOptions(selectBuilding, "GIRV");
@@ -143,47 +131,11 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     );
   });
 
-  test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
-    const sampleReturnValue = {
-      sampleKey: "sampleValue",
-      total: 0,
-    };
-
-    const fetchJSONSpy = jest.fn();
-
-    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CourseOverTimeBuildingsSearchForm fetchJSON={fetchJSONSpy} />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
-    );
-
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    userEvent.selectOptions(selectStartQuarter, "20204");
-    const selectEndQuarter = screen.getByLabelText("End Quarter");
-    userEvent.selectOptions(selectEndQuarter, "20204");
-    const selectBuilding = screen.getByLabelText("Building Name");
-    userEvent.selectOptions(selectBuilding, "GIRV");
-
-    const submitButton = screen.getByText("Submit");
-    expect(submitButton).toBeInTheDocument();
-    userEvent.click(submitButton);
-  });
-
   test("renders without crashing when fallback values are used", async () => {
     axiosMock.onGet("/api/systemInfo").reply(200, {
-      springH2ConsoleEnabled: false,
-      showSwaggerUILink: false,
-      startQtrYYYYQ: null, // use fallback value
-      endQtrYYYYQ: null, // use fallback value
+      springH2ConsoleEnabled: true,
+      showSwaggerUILink: true,
+      QtrYYYYQ: null, // use fallback value
     });
 
     render(
@@ -197,14 +149,9 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     // Make sure the first and last options
     expect(
       await screen.findByTestId(
-        "CourseOverTimeBuildingsSearch.StartQuarter-option-0",
+        "CourseOverTimeBuildingsSearch.Quarter-option-0",
       ),
-    ).toHaveValue("20211");
-    expect(
-      await screen.findByTestId(
-        "CourseOverTimeBuildingsSearch.EndQuarter-option-3",
-      ),
-    ).toHaveValue("20214");
+    ).toHaveValue("20201");
     expect(
       await screen.findByTestId(
         "CourseOverTimeBuildingsSearch.BuildingCode-option-0",
@@ -231,6 +178,43 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     expect(buttonRow).toHaveAttribute(
       "style",
       "padding-top: 10px; padding-bottom: 10px;",
+    );
+  });
+
+  test("fetches classrooms and displays them when quarter and building are selected", async () => {
+    axiosMock
+      .onGet("/api/public/courseovertime/buildingsearch/classroom", {
+        params: { quarter: "20201", buildingCode: "GIRV" },
+      })
+      .reply(200, ["1431", "1435"]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeBuildingsSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20201");
+
+    const selectBuilding = screen.getByLabelText("Building Name");
+
+    const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
+    );
+
+    await userEvent.selectOptions(selectBuilding, "GIRV");
+
+    // Wait for classroom API to be called and classrooms displayed
+    await waitFor(() =>
+      expect(screen.getByTestId("available-classrooms")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
+      "1431, 1435",
     );
   });
 });

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -22,6 +22,12 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   List<ConvertedSection> findByQuarterRangeAndInstructor(
       String startQuarter, String endQuarter, String instructor, String functionCode);
 
+  // old
+  @Query(
+      "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
+  List<ConvertedSection> findByQuarterRangeAndBuildingCode(
+      String startQuarter, String endQuarter, String buildingCode);
+  // new
   @Query(
       "{'courseInfo.quarter': { $eq: ?0 }, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")
   List<ConvertedSection> findByQuarterAndBuildingCode(String quarter, String buildingCode);

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -27,6 +27,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
+
   // new
   @Query(
       "{'courseInfo.quarter': { $eq: ?0 }, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -23,9 +23,8 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       String startQuarter, String endQuarter, String instructor, String functionCode);
 
   @Query(
-      "{'courseInfo.quarter': ?0, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")
-  List<ConvertedSection> findByQuarterAndBuildingCode(
-      String quarter, String buildingCode);
+      "{'courseInfo.quarter': { $eq: ?0 }, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")
+  List<ConvertedSection> findByQuarterAndBuildingCode(String quarter, String buildingCode);
 
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -23,9 +23,9 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       String startQuarter, String endQuarter, String instructor, String functionCode);
 
   @Query(
-      "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
-  List<ConvertedSection> findByQuarterRangeAndBuildingCode(
-      String startQuarter, String endQuarter, String buildingCode);
+      "{'courseInfo.quarter': ?0, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")
+  List<ConvertedSection> findByQuarterAndBuildingCode(
+      String quarter, String buildingCode);
 
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -52,7 +52,7 @@ public class CourseOverTimeBuildingController {
               example = "GIRV",
               required = true)
           @RequestParam
-              String buildingCode)
+          String buildingCode)
       throws JsonProcessingException {
     List<ConvertedSection> courseResults =
         convertedSectionCollection.findByQuarterRangeAndBuildingCode(
@@ -61,7 +61,7 @@ public class CourseOverTimeBuildingController {
 
     return ResponseEntity.ok().body(body);
   }
-  
+
   // new
   @Operation(
       summary =

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -34,8 +34,8 @@ public class CourseOverTimeBuildingController {
       @Parameter(
               name = "quarter",
               description =
-                  "Quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
-              example = "20231",
+                  "Quarter in yyyyq format, e.g. 20232 for S23, 20234 for F23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20232",
               required = true)
           @RequestParam
           String quarter,

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -7,8 +7,6 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -28,7 +26,9 @@ public class CourseOverTimeBuildingController {
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;
 
-  @Operation(summary = "Get a list of classroom numbers within a particular building, given a quarter and building code")
+  @Operation(
+      summary =
+          "Get a list of classroom numbers within a particular building, given a quarter and building code")
   @GetMapping(value = "/buildingsearch/classroom", produces = "application/json")
   public ResponseEntity<String> search(
       @Parameter(
@@ -48,27 +48,27 @@ public class CourseOverTimeBuildingController {
           String buildingCode)
       throws JsonProcessingException {
     List<ConvertedSection> courseResults =
-        convertedSectionCollection.findByQuarterAndBuildingCode(
-            quarter, buildingCode);
+        convertedSectionCollection.findByQuarterAndBuildingCode(quarter, buildingCode);
 
-    Set<String> classrooms = courseResults.stream()
-        .flatMap(result -> { 
-            if (result.getSection() != null && result.getSection().getTimeLocations() != null) {
-                return result.getSection().getTimeLocations().stream();
-            } else {
-                return Stream.empty();
-            }
-        })
-        .filter(loc -> loc.getBuilding() != null && loc.getBuilding().equalsIgnoreCase(buildingCode))
-        .map(loc -> loc.getRoom())
-        .filter(room -> room != null && !room.isEmpty())
-        .collect(Collectors.toCollection(TreeSet::new));
-    
-    Map<String, Object> response = new HashMap<>();
-    response.put("buildingCode", buildingCode);
-    response.put("classrooms", classrooms);
+    Set<String> classrooms =
+        courseResults.stream()
+            .flatMap(
+                result -> {
+                  if (result.getSection() != null
+                      && result.getSection().getTimeLocations() != null) {
+                    return result.getSection().getTimeLocations().stream();
+                  } else {
+                    return Stream.empty();
+                  }
+                })
+            .filter(
+                loc ->
+                    loc.getBuilding() != null && loc.getBuilding().equalsIgnoreCase(buildingCode))
+            .map(loc -> loc.getRoom())
+            .filter(room -> room != null && !room.isEmpty())
+            .collect(Collectors.toCollection(TreeSet::new));
 
-    String body = mapper.writeValueAsString(response);
+    String body = mapper.writeValueAsString(classrooms);
     return ResponseEntity.ok().body(body);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -7,6 +7,12 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,25 +28,17 @@ public class CourseOverTimeBuildingController {
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;
 
-  @Operation(summary = "Get a list of courses over time, filtered by (abbreviated) building code")
-  @GetMapping(value = "/buildingsearch", produces = "application/json")
+  @Operation(summary = "Get a list of classroom numbers within a particular building, given a quarter and building code")
+  @GetMapping(value = "/buildingsearch/classroom", produces = "application/json")
   public ResponseEntity<String> search(
       @Parameter(
-              name = "startQtr",
+              name = "quarter",
               description =
-                  "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+                  "Quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
               example = "20231",
               required = true)
           @RequestParam
-          String startQtr,
-      @Parameter(
-              name = "endQtr",
-              description =
-                  "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
-              example = "20231",
-              required = true)
-          @RequestParam
-          String endQtr,
+          String quarter,
       @Parameter(
               name = "buildingCode",
               description = "Building code such as PHELP for Phelps, GIRV for Girvetz",
@@ -50,9 +48,27 @@ public class CourseOverTimeBuildingController {
           String buildingCode)
       throws JsonProcessingException {
     List<ConvertedSection> courseResults =
-        convertedSectionCollection.findByQuarterRangeAndBuildingCode(
-            startQtr, endQtr, buildingCode);
-    String body = mapper.writeValueAsString(courseResults);
+        convertedSectionCollection.findByQuarterAndBuildingCode(
+            quarter, buildingCode);
+
+    Set<String> classrooms = courseResults.stream()
+        .flatMap(result -> { 
+            if (result.getSection() != null && result.getSection().getTimeLocations() != null) {
+                return result.getSection().getTimeLocations().stream();
+            } else {
+                return Stream.empty();
+            }
+        })
+        .filter(loc -> loc.getBuilding() != null && loc.getBuilding().equalsIgnoreCase(buildingCode))
+        .map(loc -> loc.getRoom())
+        .filter(room -> room != null && !room.isEmpty())
+        .collect(Collectors.toCollection(TreeSet::new));
+    
+    Map<String, Object> response = new HashMap<>();
+    response.put("buildingCode", buildingCode);
+    response.put("classrooms", classrooms);
+
+    String body = mapper.writeValueAsString(response);
     return ResponseEntity.ok().body(body);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -26,11 +26,48 @@ public class CourseOverTimeBuildingController {
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;
 
+  // old
+  @Operation(summary = "Get a list of courses over time, filtered by (abbreviated) building code")
+  @GetMapping(value = "/buildingsearch", produces = "application/json")
+  public ResponseEntity<String> search(
+      @Parameter(
+              name = "startQtr",
+              description =
+                  "Starting quarter in yyyyq format, e.g. 20232 for S23, 20234 for F23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20232",
+              required = true)
+          @RequestParam
+          String startQtr,
+      @Parameter(
+              name = "endQtr",
+              description =
+                  "Ending quarter in yyyyq format, e.g. 20232 for S23, 20234 for F23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20232",
+              required = true)
+          @RequestParam
+          String endQtr,
+      @Parameter(
+              name = "buildingCode",
+              description = "Building code such as PHELP for Phelps, GIRV for Girvetz",
+              example = "GIRV",
+              required = true)
+          @RequestParam
+              String buildingCode)
+      throws JsonProcessingException {
+    List<ConvertedSection> courseResults =
+        convertedSectionCollection.findByQuarterRangeAndBuildingCode(
+            startQtr, endQtr, buildingCode);
+    String body = mapper.writeValueAsString(courseResults);
+
+    return ResponseEntity.ok().body(body);
+  }
+  
+  // new
   @Operation(
       summary =
           "Get a list of classroom numbers within a particular building, given a quarter and building code")
-  @GetMapping(value = "/buildingsearch/classroom", produces = "application/json")
-  public ResponseEntity<String> search(
+  @GetMapping(value = "/buildingsearch/classrooms", produces = "application/json")
+  public ResponseEntity<String> searchNew(
       @Parameter(
               name = "quarter",
               description =

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -2,7 +2,7 @@ spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
-app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
 
 spring.data.mongodb.uri=${MONGO_URL:${env.MONGO_URL:mongodb://localhost:27017/courses}}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -39,13 +39,13 @@ public class CourseOverTimeBuildingControllerTests {
   public void test_search_emptyRequest() throws Exception {
     List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
     String urlTemplate =
-        "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingCode=%s";
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
 
-    String url = String.format(urlTemplate, "20221", "20222", "Storke Tower");
+    String url = String.format(urlTemplate, "20222", "Storke Tower");
 
     // mock
-    when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
-            any(String.class), any(String.class), any(String.class)))
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(
+            any(String.class), any(String.class)))
         .thenReturn(expectedResult);
 
     // act
@@ -81,16 +81,15 @@ public class CourseOverTimeBuildingControllerTests {
     ConvertedSection cs2 = ConvertedSection.builder().courseInfo(info).section(section2).build();
 
     String urlTemplate =
-        "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingCode=%s";
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
 
-    String url = String.format(urlTemplate, "20221", "20222", "GIRV");
+    String url = String.format(urlTemplate, "20222", "GIRV");
 
     List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
     expectedSecs.addAll(Arrays.asList(cs1, cs2));
 
     // mock
-    when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
-            any(String.class), any(String.class), eq("GIRV")))
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(String.class), eq("GIRV")))
         .thenReturn(expectedSecs);
 
     // act

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -245,29 +245,32 @@ public class CourseOverTimeBuildingControllerTests {
   // old test
   @Test
   public void test_old_endpoint_returns_course_sections() throws Exception {
-  CourseInfo info = CourseInfo.builder()
-      .quarter("20254")
-      .courseId("CMPSC 156 -1")
-      .title("Advanced Programming")
-      .description("Desc")
-      .build();
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20254")
+            .courseId("CMPSC 156 -1")
+            .title("Advanced Programming")
+            .description("Desc")
+            .build();
 
-  ConvertedSection cs = ConvertedSection.builder().courseInfo(info).build();
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).build();
 
-  when(convertedSectionCollection.findByQuarterRangeAndBuildingCode("20232", "20254", "GIRV"))
-      .thenReturn(List.of(cs));
+    when(convertedSectionCollection.findByQuarterRangeAndBuildingCode("20232", "20254", "GIRV"))
+        .thenReturn(List.of(cs));
 
-  MvcResult response = mockMvc.perform(
-      get("/api/public/courseovertime/buildingsearch")
-        .param("startQtr", "20232")
-        .param("endQtr", "20254")
-        .param("buildingCode", "GIRV")
-    ).andExpect(status().isOk()).andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(
+                get("/api/public/courseovertime/buildingsearch")
+                    .param("startQtr", "20232")
+                    .param("endQtr", "20254")
+                    .param("buildingCode", "GIRV"))
+            .andExpect(status().isOk())
+            .andReturn();
 
-  String expected = mapper.writeValueAsString(List.of(cs));
-  String actual = response.getResponse().getContentAsString();
+    String expected = mapper.writeValueAsString(List.of(cs));
+    String actual = response.getResponse().getContentAsString();
 
-  assertEquals(expected, actual);
-}
-
+    assertEquals(expected, actual);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -39,7 +39,7 @@ public class CourseOverTimeBuildingControllerTests {
   public void test_search_emptyRequest() throws Exception {
     List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
     String urlTemplate =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=%s&buildingCode=%s";
 
     String url = String.format(urlTemplate, "20222", "Storke Tower");
 
@@ -80,7 +80,7 @@ public class CourseOverTimeBuildingControllerTests {
     ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 
     String urlTemplate =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=%s&buildingCode=%s";
 
     String url = String.format(urlTemplate, "20233", "SH");
 
@@ -115,7 +115,7 @@ public class CourseOverTimeBuildingControllerTests {
             .build();
 
     String url =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=20233&buildingCode=SH";
 
     when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
         .thenReturn(List.of(cs));
@@ -137,7 +137,7 @@ public class CourseOverTimeBuildingControllerTests {
         .thenReturn(List.of(cs));
 
     String url =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=20233&buildingCode=SH";
 
     MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
     assertEquals("[]", response.getResponse().getContentAsString());
@@ -164,7 +164,7 @@ public class CourseOverTimeBuildingControllerTests {
     ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 
     String url =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=GIRV";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=20233&buildingCode=GIRV";
 
     when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("GIRV")))
         .thenReturn(List.of(cs));
@@ -195,7 +195,7 @@ public class CourseOverTimeBuildingControllerTests {
     ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 
     String url =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=20233&buildingCode=SH";
 
     when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
         .thenReturn(List.of(cs));
@@ -229,7 +229,7 @@ public class CourseOverTimeBuildingControllerTests {
     ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 
     String url =
-        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+        "/api/public/courseovertime/buildingsearch/classrooms?quarter=20233&buildingCode=SH";
 
     when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
         .thenReturn(List.of(cs));
@@ -241,4 +241,33 @@ public class CourseOverTimeBuildingControllerTests {
 
     assertEquals(expected, actual);
   }
+
+  // old test
+  @Test
+  public void test_old_endpoint_returns_course_sections() throws Exception {
+  CourseInfo info = CourseInfo.builder()
+      .quarter("20254")
+      .courseId("CMPSC 156 -1")
+      .title("Advanced Programming")
+      .description("Desc")
+      .build();
+
+  ConvertedSection cs = ConvertedSection.builder().courseInfo(info).build();
+
+  when(convertedSectionCollection.findByQuarterRangeAndBuildingCode("20232", "20254", "GIRV"))
+      .thenReturn(List.of(cs));
+
+  MvcResult response = mockMvc.perform(
+      get("/api/public/courseovertime/buildingsearch")
+        .param("startQtr", "20232")
+        .param("endQtr", "20254")
+        .param("buildingCode", "GIRV")
+    ).andExpect(status().isOk()).andReturn();
+
+  String expected = mapper.writeValueAsString(List.of(cs));
+  String actual = response.getResponse().getContentAsString();
+
+  assertEquals(expected, actual);
+}
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -13,6 +13,8 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
+import edu.ucsb.cs156.courses.documents.TimeLocation;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -66,37 +68,43 @@ public class CourseOverTimeBuildingControllerTests {
   public void test_search_validRequestWithoutSuffix() throws Exception {
     CourseInfo info =
         CourseInfo.builder()
-            .quarter("20222")
-            .courseId("CMPSC   24 -1")
-            .title("OBJ ORIENTED DESIGN")
-            .description("Intro to object oriented design")
+            .quarter("20233")
+            .courseId("CMPSC   156 -1")
+            .title("ADV APP PROGRAM")
+            .description("Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.")
             .build();
 
-    Section section1 = new Section();
+    TimeLocation loc = 
+      TimeLocation.builder()
+            .building("SH")
+            .room("1431")
+            .build();
 
-    Section section2 = new Section();
+    Section section = 
+      Section.builder()
+          .timeLocations(List.of(loc))
+          .build();
 
-    ConvertedSection cs1 = ConvertedSection.builder().courseInfo(info).section(section1).build();
-
-    ConvertedSection cs2 = ConvertedSection.builder().courseInfo(info).section(section2).build();
+    ConvertedSection cs = 
+      ConvertedSection.builder()
+          .courseInfo(info)
+          .section(section) 
+          .build();
 
     String urlTemplate =
         "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
 
-    String url = String.format(urlTemplate, "20222", "GIRV");
-
-    List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
-    expectedSecs.addAll(Arrays.asList(cs1, cs2));
+    String url = String.format(urlTemplate, "20233", "SH");
 
     // mock
-    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(String.class), eq("GIRV")))
-        .thenReturn(expectedSecs);
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(String.class), eq("SH")))
+        .thenReturn(List.of(cs));
 
     // act
     MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
 
     // assert
-    String expectedString = mapper.writeValueAsString(expectedSecs);
+    String expectedString = mapper.writeValueAsString(List.of("1431"));
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedString, responseString);
   }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -14,9 +14,7 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
 import edu.ucsb.cs156.courses.documents.TimeLocation;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,25 +69,15 @@ public class CourseOverTimeBuildingControllerTests {
             .quarter("20233")
             .courseId("CMPSC   156 -1")
             .title("ADV APP PROGRAM")
-            .description("Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.")
+            .description(
+                "Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.")
             .build();
 
-    TimeLocation loc = 
-      TimeLocation.builder()
-            .building("SH")
-            .room("1431")
-            .build();
+    TimeLocation loc = TimeLocation.builder().building("SH").room("1431").build();
 
-    Section section = 
-      Section.builder()
-          .timeLocations(List.of(loc))
-          .build();
+    Section section = Section.builder().timeLocations(List.of(loc)).build();
 
-    ConvertedSection cs = 
-      ConvertedSection.builder()
-          .courseInfo(info)
-          .section(section) 
-          .build();
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 
     String urlTemplate =
         "/api/public/courseovertime/buildingsearch/classroom?quarter=%s&buildingCode=%s";
@@ -107,5 +95,150 @@ public class CourseOverTimeBuildingControllerTests {
     String expectedString = mapper.writeValueAsString(List.of("1431"));
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedString, responseString);
+  }
+
+  @Test
+  public void test_search_sectionIsNull() throws Exception {
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20233")
+            .courseId("CMPSC   156 -1")
+            .title("ADV APP PROGRAM")
+            .description(
+                "Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.")
+            .build();
+
+    ConvertedSection cs =
+        ConvertedSection.builder()
+            .courseInfo(info)
+            .section(null) // missing section
+            .build();
+
+    String url =
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
+        .thenReturn(List.of(cs));
+
+    MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+    String expectedString = mapper.writeValueAsString(List.of());
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedString, responseString);
+  }
+
+  @Test
+  public void test_search_timeLocationsIsNull() throws Exception {
+    Section section = Section.builder().timeLocations(null).build();
+    ConvertedSection cs = ConvertedSection.builder().section(section).build();
+
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
+        .thenReturn(List.of(cs));
+
+    String url =
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+
+    MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+    assertEquals("[]", response.getResponse().getContentAsString());
+  }
+
+  @Test
+  public void test_search_buildingDoesNotMatch() throws Exception {
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20233")
+            .courseId("CMPSC   156 -1")
+            .title("ADV APP PROGRAM")
+            .description("desc")
+            .build();
+
+    TimeLocation loc =
+        TimeLocation.builder()
+            .building("PHELP") // Not GIRV
+            .room("1431")
+            .build();
+
+    Section section = Section.builder().timeLocations(List.of(loc)).build();
+
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
+
+    String url =
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=GIRV";
+
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("GIRV")))
+        .thenReturn(List.of(cs));
+
+    MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+    String expectedString = mapper.writeValueAsString(List.of());
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedString, responseString);
+  }
+
+  @Test
+  public void test_search_buildingIsNull_skipsLocation() throws Exception {
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20233")
+            .courseId("CMPSC   156 -1")
+            .title("ADV APP PROGRAM")
+            .description("desc")
+            .build();
+
+    // TimeLocation with null building
+    TimeLocation loc = TimeLocation.builder().building(null).room("1431").build();
+
+    Section section = Section.builder().timeLocations(List.of(loc)).build();
+
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
+
+    String url =
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
+        .thenReturn(List.of(cs));
+
+    MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+    String expected = mapper.writeValueAsString(List.of());
+    String actual = response.getResponse().getContentAsString();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void test_search_roomNullOrEmpty_skipsRoom() throws Exception {
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20233")
+            .courseId("CMPSC   156 -1")
+            .title("ADV APP PROGRAM")
+            .description("desc")
+            .build();
+
+    // room is null
+    TimeLocation loc1 = TimeLocation.builder().building("SH").room(null).build();
+
+    // room is empty
+    TimeLocation loc2 = TimeLocation.builder().building("SH").room("").build();
+
+    Section section = Section.builder().timeLocations(List.of(loc1, loc2)).build();
+
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
+
+    String url =
+        "/api/public/courseovertime/buildingsearch/classroom?quarter=20233&buildingCode=SH";
+
+    when(convertedSectionCollection.findByQuarterAndBuildingCode(any(), eq("SH")))
+        .thenReturn(List.of(cs));
+
+    MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+    String expected = mapper.writeValueAsString(List.of());
+    String actual = response.getResponse().getContentAsString();
+
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
Closes #9 

Dokku deployment link: https://courses-dev-evaniacheng.dokku-02.cs.ucsb.edu/
You will be able to see swagger and you can test the api endpoint /api/public/courseovertime/buildingsearch/classroom. The original /api/public/courseovertime/buildingsearch endpoint still works and the course location history page also does too. 

In this PR, I edited the MongoDB query, its parameters, the building controller, and its test. The API endpoint now takes in one quarter (instead of a quarter range) and also a building code. It returns a set of strings of the classrooms in that building that are used during that quarter. 
 
<img width="1320" alt="Screenshot 2025-05-15 at 12 36 44 PM" src="https://github.com/user-attachments/assets/d760ae96-2064-420d-a54a-462ebeb568d0" />
<img width="1313" alt="Screenshot 2025-05-15 at 12 36 59 PM" src="https://github.com/user-attachments/assets/36ed2432-d53e-460d-9a75-57b86d65ba65" />
In this example, all the classrooms in South Hall used during Spring quarter of 2023 are outputted in the set. 
