### PR TITLE
mc - add placeholder page for GE search

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,6 +24,8 @@ import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseO
 
 import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage";
 
+import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
+
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -95,6 +97,11 @@ function App() {
           exact
           path="/coursedetails/:qtr/:enrollCode"
           element={<CourseDetailsIndexPage />}
+        />
+        <Route
+          exact
+          path="/generaleducation/search"
+          element={<GeneralEducationSearchPage />}
         />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -98,6 +98,12 @@ export default function AppNavbar({
                 >
                   Search by Instructor
                 </NavDropdown.Item>
+                <NavDropdown.Item
+                  href="/generaleducation/search"
+                  data-testid="appnavbar-ge-search"
+                >
+                  GE Search
+                </NavDropdown.Item>
               </NavDropdown>
             </Nav>
 

--- a/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
@@ -2,7 +2,7 @@ import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 export default function GeneralEducationSearchPage() {
   return (
-    <div className="container mt-3">
+    <BasicLayout>
       <h1>GE Search coming soon!</h1>
     </div>
   );

--- a/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
@@ -4,6 +4,6 @@ export default function GeneralEducationSearchPage() {
   return (
     <BasicLayout>
       <h1>GE Search coming soon!</h1>
-    </div>
+        </BasicLayout>
   );
 }

--- a/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function GeneralEducationSearchPage() {
+  return (
+    <div className="container mt-3">
+      <h1>GE Search coming soon!</h1>
+    </div>
+  );
+}

--- a/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 export default function GeneralEducationSearchPage() {
   return (
     <div className="container mt-3">

--- a/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/Search/GeneralEducationSearchPage.js
@@ -1,9 +1,12 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
 export default function GeneralEducationSearchPage() {
   return (
     <BasicLayout>
-      <h1>GE Search coming soon!</h1>
-        </BasicLayout>
+      <div className="container mt-3">
+        <h1>GE Search coming soon!</h1>
+      </div>
+    </BasicLayout>
   );
 }

--- a/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
+
+describe("GeneralEducationSearchPage tests", () => {
+  test("renders without crashing and shows placeholder text", () => {
+    render(<GeneralEducationSearchPage />);
+    const heading = screen.getByText(/GE Search coming soon!/i);
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
@@ -3,13 +3,17 @@ import { MemoryRouter } from "react-router-dom";
 import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
 
 jest.mock("main/utils/currentUser", () => ({
-  useCurrentUser: () => ({ data: { loggedIn: false } }),
+  useCurrentUser: () => ({
+    data: { loggedIn: false, root: { user: { email: "test@example.com" } } }
+  }),
   useLogout: () => ({ mutate: jest.fn() }),
+  hasRole: (user, role) => false // or customize per role
 }));
 
 jest.mock("main/utils/systemInfo", () => ({
   useSystemInfo: () => ({ data: {} }),
 }));
+
 
 describe("GeneralEducationSearchPage tests", () => {
   test("renders without crashing and shows placeholder text", () => {

--- a/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
@@ -7,7 +7,7 @@ jest.mock("main/utils/currentUser", () => ({
     data: { loggedIn: false, root: { user: { email: "test@example.com" } } },
   }),
   useLogout: () => ({ mutate: jest.fn() }),
-  hasRole: (user, role) => false, // or customize per role
+  hasRole: (_user, _role) => false, // or customize per role
 }));
 
 jest.mock("main/utils/systemInfo", () => ({

--- a/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
@@ -4,23 +4,22 @@ import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/Gener
 
 jest.mock("main/utils/currentUser", () => ({
   useCurrentUser: () => ({
-    data: { loggedIn: false, root: { user: { email: "test@example.com" } } }
+    data: { loggedIn: false, root: { user: { email: "test@example.com" } } },
   }),
   useLogout: () => ({ mutate: jest.fn() }),
-  hasRole: (user, role) => false // or customize per role
+  hasRole: (user, role) => false, // or customize per role
 }));
 
 jest.mock("main/utils/systemInfo", () => ({
   useSystemInfo: () => ({ data: {} }),
 }));
 
-
 describe("GeneralEducationSearchPage tests", () => {
   test("renders without crashing and shows placeholder text", () => {
     render(
       <MemoryRouter>
         <GeneralEducationSearchPage />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const heading = screen.getByText(/GE Search coming soon!/i);

--- a/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/GeneralEducation/Search/GeneralEducationSearchPage.test.js
@@ -1,9 +1,24 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import GeneralEducationSearchPage from "main/pages/GeneralEducation/Search/GeneralEducationSearchPage";
+
+jest.mock("main/utils/currentUser", () => ({
+  useCurrentUser: () => ({ data: { loggedIn: false } }),
+  useLogout: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("main/utils/systemInfo", () => ({
+  useSystemInfo: () => ({ data: {} }),
+}));
 
 describe("GeneralEducationSearchPage tests", () => {
   test("renders without crashing and shows placeholder text", () => {
-    render(<GeneralEducationSearchPage />);
+    render(
+      <MemoryRouter>
+        <GeneralEducationSearchPage />
+      </MemoryRouter>
+    );
+
     const heading = screen.getByText(/GE Search coming soon!/i);
     expect(heading).toBeInTheDocument();
   });


### PR DESCRIPTION
Closes #16 

Dokku deployment link: https://courses-dev-mujiaaa.dokku-02.cs.ucsb.edu/

In this PR, I create a placeholder page for GE search. 
The page is added to the navbar, under the dropdown with the other search types.

<img width="1707" alt="Screenshot 2025-05-16 at 1 45 24 PM" src="https://github.com/user-attachments/assets/110daf03-2452-4b4c-87ce-35166ca82ab9" />

<img width="1470" alt="Screenshot 2025-05-18 at 7 48 48 PM" src="https://github.com/user-attachments/assets/b7317d54-1b62-470e-9863-56c8b482f18d" />

As in the screenshot, you can find GE search under the dropdown with the other search types, and it contain the text "GE Search coming soon!".