### PR TITLE
ec - Fetched list of classrooms based on building in frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -83,7 +83,7 @@ function App() {
         />
         <Route
           exact
-          path="/courseovertime/buildingsearch"
+          path="/courseovertime/buildingsearch/classrooms"
           element={<CourseOverTimeBuildingsIndexPage />}
         />
         <Route

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
@@ -12,9 +12,11 @@ import SingleBuildingDropdown from "../Buildings/SingleBuildingDropdown";
 const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
   const { data: systemInfo } = useSystemInfo();
 
-  const availableQuarters = systemInfo
-    ? quarterRange(systemInfo.startQtrYYYYQ, systemInfo.endQtrYYYYQ)
-    : [];
+  // stryker-disable OptionalChaining
+  const startQtr = systemInfo?.startQtrYYYYQ ?? "20232";
+  const endQtr = systemInfo?.endQtrYYYYQ ?? "20254";
+  // stryker-enable OptionalChaining
+  const availableQuarters = quarterRange(startQtr, endQtr);
 
   const localQuarter = localStorage.getItem(
     "CourseOverTimeBuildingsSearch.Quarter",

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import axios from "axios";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
 import { allBuildings } from "fixtures/buildingFixtures";
@@ -11,38 +12,52 @@ import SingleBuildingDropdown from "../Buildings/SingleBuildingDropdown";
 const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
   const { data: systemInfo } = useSystemInfo();
 
-  // Stryker disable OptionalChaining
-  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
-  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker restore OptionalChaining
+  const availableQuarters = systemInfo
+    ? quarterRange(systemInfo.startQtrYYYYQ, systemInfo.endQtrYYYYQ)
+    : [];
 
-  const quarters = quarterRange(startQtr, endQtr);
-
-  // Stryker disable all : not sure how to test/mock local storage
-  const localStartQuarter = localStorage.getItem(
-    "CourseOverTimeBuildingsSearch.StartQuarter",
-  );
-  const localEndQuarter = localStorage.getItem(
-    "CourseOverTimeBuildingsSearch.EndQuarter",
+  const localQuarter = localStorage.getItem(
+    "CourseOverTimeBuildingsSearch.Quarter",
   );
   const localBuildingCode = localStorage.getItem(
     "CourseOverTimeBuildingsSearch.BuildingCode",
   );
 
-  const [startQuarter, setStartQuarter] = useState(
-    localStartQuarter || quarters[0].yyyyq,
+  const [Quarter, setQuarter] = useState(
+    localQuarter || availableQuarters[0]?.yyyyq,
   );
-  const [endQuarter, setEndQuarter] = useState(
-    localEndQuarter || quarters[0].yyyyq,
-  );
-  const [buildingCode, setBuildingCode] = useState(localBuildingCode || {});
-
-  // Stryker restore all
+  const [buildingCode, setBuildingCode] = useState(localBuildingCode || "");
+  const [availableClassrooms, setAvailableClassrooms] = useState([]);
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { startQuarter, endQuarter, buildingCode });
+    fetchJSON(event, { Quarter, buildingCode, classroom: "" });
   };
+
+  useEffect(() => {
+    async function fetchClassrooms() {
+      if (Quarter && buildingCode) {
+        try {
+          console.log("Fetching classrooms with:", { Quarter, buildingCode });
+          const response = await axios.get(
+            "/api/public/courseovertime/buildingsearch/classrooms",
+            {
+              params: { quarter: Quarter, buildingCode },
+            },
+          );
+          console.log("Classrooms returned:", response.data);
+
+          const classrooms = response.data.sort();
+
+          setAvailableClassrooms(classrooms);
+        } catch (error) {
+          console.error("Error fetching classrooms", error);
+          setAvailableClassrooms([]);
+        }
+      }
+    }
+    fetchClassrooms();
+  }, [Quarter, buildingCode]);
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -50,20 +65,11 @@ const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
         <Row>
           <Col md="auto">
             <SingleQuarterDropdown
-              quarters={quarters}
-              quarter={startQuarter}
-              setQuarter={setStartQuarter}
-              controlId={"CourseOverTimeBuildingsSearch.StartQuarter"}
-              label={"Start Quarter"}
-            />
-          </Col>
-          <Col md="auto">
-            <SingleQuarterDropdown
-              quarters={quarters}
-              quarter={endQuarter}
-              setQuarter={setEndQuarter}
-              controlId={"CourseOverTimeBuildingsSearch.EndQuarter"}
-              label={"End Quarter"}
+              quarters={availableQuarters}
+              quarter={Quarter}
+              setQuarter={setQuarter}
+              controlId={"CourseOverTimeBuildingsSearch.Quarter"}
+              label={"Quarter"}
             />
           </Col>
           <Col md="auto">
@@ -83,6 +89,11 @@ const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
             </Button>
           </Col>
         </Row>
+        {availableClassrooms.length > 0 && (
+          <div data-testid="available-classrooms">
+            {availableClassrooms.join(", ")}
+          </div>
+        )}
       </Container>
     </Form>
   );

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.js
@@ -26,7 +26,7 @@ const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
   );
 
   const [Quarter, setQuarter] = useState(
-    localQuarter || availableQuarters[0]?.yyyyq,
+    localQuarter || availableQuarters[0].yyyyq,
   );
   const [buildingCode, setBuildingCode] = useState(localBuildingCode || "");
   const [availableClassrooms, setAvailableClassrooms] = useState([]);
@@ -48,7 +48,6 @@ const CourseOverTimeBuildingsSearchForm = ({ fetchJSON }) => {
             },
           );
           console.log("Classrooms returned:", response.data);
-
           const classrooms = response.data.sort();
 
           setAvailableClassrooms(classrooms);

--- a/frontend/src/main/components/Jobs/UpdateCoursesByQuarterJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesByQuarterJobForm.js
@@ -16,7 +16,11 @@ const UpdateCoursesByQuarterJobForm = ({ callback }) => {
   // Stryker enable OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
-  const [quarter, setQuarter] = useState(quarters[0].yyyyq);
+  const storedQuarter = localStorage.getItem(
+    "UpdateCoursesByQuarterJobForm.Quarter",
+  );
+  const initialQuarter = storedQuarter ?? quarters[0].yyyyq;
+  const [quarter, setQuarter] = useState(initialQuarter);
   const [ifStale, setIfStale] = useState(true);
 
   const handleSubmit = (event) => {

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -87,7 +87,7 @@ export default function AppNavbar({
                   Course History
                 </NavDropdown.Item>
                 <NavDropdown.Item
-                  href="/courseovertime/buildingsearch"
+                  href="/courseovertime/buildingsearch/classrooms"
                   data-testid="appnavbar-course-over-time-buildings-search"
                 >
                   Course Location History

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -35,7 +35,7 @@ function SingleQuarterDropdown({
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    quarter.yyyyq || localSearchQuarter || quarters[lastInd].yyyyq,
+    quarter || localSearchQuarter || quarters[lastInd].yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
@@ -9,11 +9,11 @@ export default function CourseOverTimeBuildingsIndexPage() {
   const [courseJSON, setCourseJSON] = useState([]);
 
   const objectToAxiosParams = (query) => ({
-    url: "/api/public/courseovertime/buildingsearch/classrooms",
+    url: "/api/public/courseovertime/buildingsearch",
     params: {
-      quarter: query.Quarter,
+      startQtr: query.Quarter,
+      endQtr: query.Quarter,
       buildingCode: query.buildingCode,
-      classroom: query.classroom,
     },
   });
 

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
@@ -9,11 +9,11 @@ export default function CourseOverTimeBuildingsIndexPage() {
   const [courseJSON, setCourseJSON] = useState([]);
 
   const objectToAxiosParams = (query) => ({
-    url: "/api/public/courseovertime/buildingsearch",
+    url: "/api/public/courseovertime/buildingsearch/classrooms",
     params: {
-      startQtr: query.startQuarter,
-      endQtr: query.endQuarter,
+      quarter: query.Quarter,
       buildingCode: query.buildingCode,
+      classroom: query.classroom,
     },
   });
 

--- a/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.stories.js
@@ -1,31 +1,55 @@
-import CourseOverTimeSearchBuildingsForm from "main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm";
+import CourseOverTimeBuildingsSearchForm from "main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import { toast } from "react-toastify";
 import { http, HttpResponse } from "msw";
 
 export default {
-  title: "components/BasicCourseSearch/CourseOverTimeBuildingsSearch",
-  component: CourseOverTimeSearchBuildingsForm,
+  title: "components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm",
+  component: CourseOverTimeBuildingsSearchForm,
 };
 
 const Template = (args) => {
-  return <CourseOverTimeSearchBuildingsForm {...args} />;
+  return <CourseOverTimeBuildingsSearchForm {...args} />;
 };
 
 export const Default = Template.bind({});
-
 Default.args = {
   fetchJSON: (_event, data) => {
     toast(`Submit was clicked, data=${JSON.stringify(data)}`);
   },
 };
+
 Default.parameters = {
   msw: [
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingBothStartAndEndQtr, {
-        status: 200,
-      });
-    }),
+    // Mock system info for quarters
+    http.get("/api/systemInfo", () =>
+      HttpResponse.json(systemInfoFixtures.showingBothStartAndEndQtr),
+    ),
+
+    // Mock classroom data when quarter and buildingCode are provided
+    http.get(
+      "/api/public/courseovertime/buildingsearch/classrooms",
+      ({ request }) => {
+        const url = new URL(request.url);
+        const quarter = url.searchParams.get("quarter");
+        const buildingCode = url.searchParams.get("buildingCode");
+
+        if (quarter && buildingCode) {
+          return HttpResponse.json([
+            {
+              section: {
+                timeLocations: [
+                  { building: buildingCode, room: "101" },
+                  { building: buildingCode, room: "102" },
+                ],
+              },
+            },
+          ]);
+        }
+
+        return HttpResponse.json([]);
+      },
+    ),
   ],
 };

--- a/frontend/src/stories/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.stories.js
+++ b/frontend/src/stories/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.stories.js
@@ -29,7 +29,7 @@ Default.parameters = {
     http.get("/api/currentUser", () => {
       return HttpResponse.status(403); // returns 403 when not logged in
     }),
-    http.get("/api/public/courseovertime/buildingsearch", () => {
+    http.get("/api/public/courseovertime/buildingsearch/classrooms", () => {
       return HttpResponse.json(coursesInLib, {
         status: 200,
       });

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -302,12 +302,10 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
 
     userEvent.selectOptions(screen.getByLabelText("Building Name"), "GIRV");
 
-    await waitFor(() => {
-      expect(console.error).toHaveBeenCalled();
-      expect(
-        screen.queryByTestId("available-classrooms"),
-      ).not.toBeInTheDocument();
-    });
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(
+      screen.queryByTestId("available-classrooms"),
+    ).not.toBeInTheDocument();
   });
 
   test("uses fallback quarter/building when localStorage for quarter/building is null", () => {

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -92,9 +92,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     );
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     const selectBuilding = screen.getByLabelText("Building Name");
     userEvent.selectOptions(selectBuilding, "BRDA");
@@ -126,9 +124,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     };
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20232");
@@ -237,15 +233,11 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     userEvent.selectOptions(selectBuilding, "GIRV");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("available-classrooms")).toBeInTheDocument(),
-    );
+    await screen.findByTestId("available-classrooms");
 
     expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
       "1004, 1106, 1108, 1112, 1115, 1116, 1119, 2108, 2110, 2112, 2115, 2116, 2119, 2120, 2123, 2124, 2127, 2128, 2129, 2135",
@@ -277,15 +269,11 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     userEvent.selectOptions(screen.getByLabelText("Quarter"), "20232");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     userEvent.selectOptions(screen.getByLabelText("Building Name"), "GIRV");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("available-classrooms")).toBeInTheDocument(),
-    );
+    await screen.findByTestId("available-classrooms");
 
     expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
       "1004, 1106, 1108",
@@ -310,9 +298,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     userEvent.selectOptions(screen.getByLabelText("Quarter"), "20232");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     userEvent.selectOptions(screen.getByLabelText("Building Name"), "GIRV");
 

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -6,37 +6,50 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import CourseOverTimeBuildingsSearchForm from "main/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm";
+
+import { useSystemInfo } from "main/utils/systemInfo";
+
+jest.mock("main/utils/systemInfo", () => ({
+  useSystemInfo: jest.fn(),
+}));
 
 jest.mock("react-toastify", () => ({
   toast: jest.fn(),
 }));
 
 describe("CourseOverTimeBuildingsSearchForm tests", () => {
+  const mockFn = jest.fn();
   const axiosMock = new AxiosMockAdapter(axios);
 
   const queryClient = new QueryClient();
   const addToast = jest.fn();
 
   beforeEach(() => {
+    localStorage.clear();
     jest.clearAllMocks();
     jest.spyOn(console, "error");
     console.error.mockImplementation(() => null);
+
+    useSystemInfo.mockReturnValue({
+      data: {
+        startQtrYYYYQ: "20232",
+        endQtrYYYYQ: "20254",
+      },
+    });
 
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock.onGet("/api/systemInfo").reply(200, {
       springH2ConsoleEnabled: false,
-      showSwaggerUILink: true,
+      showSwaggerUILink: false,
       startQtrYYYYQ: "20232",
       endQtrYYYYQ: "20254",
     });
-
     axiosMock
       .onGet("/api/public/basicQuarterDates")
       .reply(200, [{ yyyyq: "20232" }, { yyyyq: "20242" }, { yyyyq: "20252" }]);
@@ -136,9 +149,8 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
   test("renders without crashing when fallback values are used", async () => {
     axiosMock.onGet("/api/systemInfo").reply(200, {
       springH2ConsoleEnabled: false,
-      showSwaggerUILink: true,
-      startQtrYYYYQ: null, // use fallback value
-      endQtrYYYYQ: null, // use fallback value
+      showSwaggerUILink: false,
+      quarterYYYYQ: null,
     });
 
     render(
@@ -149,7 +161,6 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
       </QueryClientProvider>,
     );
 
-    // Make sure the first and last options
     expect(
       await screen.findByTestId(
         "CourseOverTimeBuildingsSearch.Quarter-option-0",
@@ -232,7 +243,6 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
 
     userEvent.selectOptions(selectBuilding, "GIRV");
 
-    // Wait for classroom API to be called and classrooms displayed
     await waitFor(() =>
       expect(screen.getByTestId("available-classrooms")).toBeInTheDocument(),
     );
@@ -240,5 +250,193 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
       "1004, 1106, 1108, 1112, 1115, 1116, 1119, 2108, 2110, 2112, 2115, 2116, 2119, 2120, 2123, 2124, 2127, 2128, 2129, 2135",
     );
+  });
+
+  test("renders nothing when classrooms is empty", () => {
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={mockFn} />);
+    expect(
+      screen.queryByTestId("available-classrooms"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("fetches classrooms and displays them in sorted order", async () => {
+    axiosMock
+      .onGet("/api/public/courseovertime/buildingsearch/classrooms", {
+        params: { quarter: "20232", buildingCode: "GIRV" },
+      })
+      .reply(200, ["1108", "1004", "1106"]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeBuildingsSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    userEvent.selectOptions(screen.getByLabelText("Quarter"), "20232");
+
+    const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
+    );
+
+    userEvent.selectOptions(screen.getByLabelText("Building Name"), "GIRV");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("available-classrooms")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
+      "1004, 1106, 1108",
+    );
+  });
+
+  test("displays no classrooms and logs error when fetch fails", async () => {
+    axiosMock
+      .onGet("/api/public/courseovertime/buildingsearch/classrooms", {
+        params: { quarter: "20232", buildingCode: "GIRV" },
+      })
+      .networkError();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeBuildingsSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    userEvent.selectOptions(screen.getByLabelText("Quarter"), "20232");
+
+    const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
+    );
+
+    userEvent.selectOptions(screen.getByLabelText("Building Name"), "GIRV");
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalled();
+      expect(
+        screen.queryByTestId("available-classrooms"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("uses fallback quarter/building when localStorage for quarter/building is null", () => {
+    useSystemInfo.mockReturnValue({
+      data: { startQtrYYYYQ: "20222", endQtrYYYYQ: "20232" },
+    });
+    localStorage.removeItem("CourseOverTimeBuildingsSearch.Quarter");
+    localStorage.setItem("CourseOverTimeBuildingsSearch.BuildingCode", null);
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    expect(screen.getByLabelText("Quarter")).toBeInTheDocument();
+    expect(screen.getByLabelText("Building Name")).toBeInTheDocument();
+  });
+
+  test("does not fetch classrooms if Quarter or buildingCode is missing", async () => {
+    useSystemInfo.mockReturnValue({ data: {} });
+    const getSpy = jest.spyOn(axios, "get");
+
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    await waitFor(() => expect(getSpy).not.toHaveBeenCalled());
+
+    localStorage.removeItem("CourseOverTimeBuildingsSearch.Quarter");
+    localStorage.removeItem("CourseOverTimeBuildingsSearch.BuildingCode");
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    await waitFor(() => expect(getSpy).not.toHaveBeenCalled());
+  });
+
+  test("fetches classrooms if both Quarter and buildingCode exist", async () => {
+    useSystemInfo.mockReturnValue({ data: {} });
+    localStorage.setItem("CourseOverTimeBuildingsSearch.Quarter", "20222");
+    localStorage.setItem("CourseOverTimeBuildingsSearch.BuildingCode", "PHELP");
+    axios.get.mockResolvedValue({ data: ["CLSS1", "CLSS2"] });
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    await waitFor(() => expect(axios.get).toHaveBeenCalled());
+  });
+
+  test("handles error when classroom fetch fails", async () => {
+    useSystemInfo.mockReturnValue({ data: {} });
+    localStorage.setItem("CourseOverTimeBuildingsSearch.Quarter", "20222");
+    localStorage.setItem("CourseOverTimeBuildingsSearch.BuildingCode", "PHELP");
+
+    const error = new Error("Network error");
+    axios.get.mockRejectedValue(error);
+
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith("Error fetching classrooms", error);
+    });
+
+    errorSpy.mockRestore();
+  });
+
+  test("logs classrooms when fetch is successful", async () => {
+    useSystemInfo.mockReturnValue({ data: {} });
+    localStorage.setItem("CourseOverTimeBuildingsSearch.Quarter", "20222");
+    localStorage.setItem("CourseOverTimeBuildingsSearch.BuildingCode", "PHELP");
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    axios.get.mockResolvedValue({ data: ["CLSS1"] });
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    await waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Fetching classrooms with:"),
+        { Quarter: "20222", buildingCode: "PHELP" },
+      ),
+    );
+    await waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Classrooms returned:"),
+        expect.any(Array),
+      ),
+    );
+    logSpy.mockRestore();
+  });
+
+  test("sorts classroom list alphabetically", async () => {
+    useSystemInfo.mockReturnValue({ data: {} });
+    localStorage.setItem("CourseOverTimeBuildingsSearch.Quarter", "20222");
+    localStorage.setItem("CourseOverTimeBuildingsSearch.BuildingCode", "PHELP");
+    axios.get.mockResolvedValue({ data: ["Z101", "A202", "M303"] });
+    render(<CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("available-classrooms")).toHaveTextContent(
+        "A202, M303, Z101",
+      ),
+    );
+  });
+
+  test("uses first available quarter if localQuarter is falsy", () => {
+    localStorage.removeItem("CourseOverTimeBuildingsSearch.Quarter");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const selectQuarter = screen.getByLabelText("Quarter");
+    expect(selectQuarter.value).toBe("20232");
+  });
+
+  test("falls back to default endQtr when systemInfo is undefined", () => {
+    useSystemInfo.mockReturnValue({ data: undefined });
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <CourseOverTimeBuildingsSearchForm fetchJSON={jest.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByLabelText("Quarter")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -16,9 +16,9 @@ jest.mock("react-toastify", () => ({
   toast: jest.fn(),
 }));
 
-describe("CourseOverTimeBuildingsSearchForm tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+const axiosMock = new AxiosMockAdapter(axios);
 
+describe("CourseOverTimeBuildingsSearchForm tests", () => {
   const queryClient = new QueryClient();
   const addToast = jest.fn();
 
@@ -27,17 +27,19 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     jest.spyOn(console, "error");
     console.error.mockImplementation(() => null);
 
+    axiosMock.reset();
+
+    axiosMock.onGet("/api/systemInfo").reply(200, {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: true,
+      startQtrYYYYQ: "20232",
+      endQtrYYYYQ: "20254",
+    });
+
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, {
-      ...systemInfoFixtures.showingNeither,
-      quarterYYYYQ: [
-        { yyyyq: "20232" },
-        { yyyyq: "20242" },
-        { yyyyq: "20252" },
-      ],
-    });
+
     axiosMock
       .onGet("/api/public/basicQuarterDates")
       .reply(200, [{ yyyyq: "20232" }, { yyyyq: "20242" }, { yyyyq: "20252" }]);
@@ -110,6 +112,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     const expectedFields = {
       Quarter: "20232",
       buildingCode: "GIRV",
+      classroom: "",
     };
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
@@ -138,6 +141,8 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
       springH2ConsoleEnabled: false,
       showSwaggerUILink: true,
       quarterYYYYQ: null, // use fallback value
+      startQtrYYYYQ: "20232",
+      endQtrYYYYQ: "20254",
     });
 
     render(
@@ -153,7 +158,7 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
       await screen.findByTestId(
         "CourseOverTimeBuildingsSearch.Quarter-option-0",
       ),
-    ).toHaveValue("20201");
+    ).toHaveValue("20232");
     expect(
       await screen.findByTestId(
         "CourseOverTimeBuildingsSearch.BuildingCode-option-0",

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeBuildingsSearchForm.test.js
@@ -16,9 +16,9 @@ jest.mock("react-toastify", () => ({
   toast: jest.fn(),
 }));
 
-const axiosMock = new AxiosMockAdapter(axios);
-
 describe("CourseOverTimeBuildingsSearchForm tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
   const queryClient = new QueryClient();
   const addToast = jest.fn();
 
@@ -27,18 +27,15 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     jest.spyOn(console, "error");
     console.error.mockImplementation(() => null);
 
-    axiosMock.reset();
-
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock.onGet("/api/systemInfo").reply(200, {
       springH2ConsoleEnabled: false,
       showSwaggerUILink: true,
       startQtrYYYYQ: "20232",
       endQtrYYYYQ: "20254",
     });
-
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
 
     axiosMock
       .onGet("/api/public/basicQuarterDates")
@@ -140,9 +137,8 @@ describe("CourseOverTimeBuildingsSearchForm tests", () => {
     axiosMock.onGet("/api/systemInfo").reply(200, {
       springH2ConsoleEnabled: false,
       showSwaggerUILink: true,
-      quarterYYYYQ: null, // use fallback value
-      startQtrYYYYQ: "20232",
-      endQtrYYYYQ: "20254",
+      startQtrYYYYQ: null, // use fallback value
+      endQtrYYYYQ: null, // use fallback value
     });
 
     render(

--- a/frontend/src/tests/components/Jobs/UpdateCoursesByQuarterJobForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCoursesByQuarterJobForm.test.js
@@ -13,12 +13,6 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
-// const mockedUseSystemInfo = jest.fn();
-
-// jest.mock("main/utils/systemInfo", () => ({
-//   useSystemInfo: () => mockedUseSystemInfo,
-// }));
-
 const queryClient = new QueryClient();
 
 describe("UpdateCoursesByQuarterJobForm tests", () => {
@@ -118,7 +112,7 @@ describe("UpdateCoursesByQuarterJobForm tests", () => {
     ).toHaveValue("20194");
 
     // Assert: make sure option from local storage is selected
-    expect(screen.getByRole("option", { name: /M19/i }).selected).toBeTruthy();
+    expect(screen.getByLabelText("Quarter").value).toBe("20193");
   });
 
   test("works when local storage doesn't have a value", async () => {
@@ -153,10 +147,6 @@ describe("UpdateCoursesByQuarterJobForm tests", () => {
     expect(getItemSpy).toHaveBeenCalledWith(
       "UpdateCoursesByQuarterJobForm.Quarter",
     );
-
-    expect(screen.queryByRole("option", { name: /W19/i }).selected).toBeFalsy();
-    expect(screen.queryByRole("option", { name: /S19/i }).selected).toBeFalsy();
-    expect(screen.queryByRole("option", { name: /M19/i }).selected).toBeFalsy();
-    expect(screen.getByRole("option", { name: /F19/i }).selected).toBeTruthy();
+    expect(screen.getByLabelText("Quarter").value).toBe("20191");
   });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -190,42 +190,38 @@ describe("SingleQuarterSelector tests", () => {
     expect(await screen.findByTestId(expectedKey)).toBeInTheDocument();
   });
 
-  test("when localstorage has a value, it is passed to useState", async () => {
+  test("when localstorage has a value, it is selected in dropdown", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => "20202");
-
-    const setQuarterStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
 
     render(
       <SingleQuarterDropdown
         quarters={quarterRange("20201", "20224")}
-        quarter={quarter}
+        quarter={null} // allow internal fallback to run
         setQuarter={setQuarter}
         controlId="sqd1"
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20202"));
+    const select = await screen.findByTestId("sqd1");
+    expect(select.value).toBe("20202");
   });
 
-  test("when localstorage has no value last element of quarter range is passed to useState", async () => {
+  test("when localstorage has no value, last element of quarter range is selected", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
-
-    const setQuarterStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
 
     render(
       <SingleQuarterDropdown
         quarters={quarterRange("20201", "20234")}
-        quarter={quarter}
+        quarter={null} // allow internal fallback to run
         setQuarter={setQuarter}
         controlId="sqd1"
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20234"));
+    const select = await screen.findByTestId("sqd1");
+    expect(select.value).toBe("20234");
   });
 
   test("when localstorage has no value, last element of quarter range is the default parameter", async () => {

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
@@ -73,6 +73,8 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
 
     axiosMock.resetHistory();
 
+    axiosMock.resetHistory();
+
     const submitButton = screen.getByText("Submit");
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
@@ -49,7 +49,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
 
   test("calls UCSB Course over time search api correctly with correct response", async () => {
     axiosMock
-      .onGet("/api/public/courseovertime/buildingsearch")
+      .onGet("/api/public/courseovertime/buildingsearch/classrooms")
       .reply(200, coursesInLib);
 
     render(
@@ -60,41 +60,39 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    userEvent.selectOptions(selectStartQuarter, "20222");
-    const selectEndQuarter = screen.getByLabelText("End Quarter");
-    userEvent.selectOptions(selectEndQuarter, "20222");
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20232");
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
     );
 
     userEvent.selectOptions(selectBuilding, "GIRV");
 
+    axiosMock.resetHistory();
+
     const submitButton = screen.getByText("Submit");
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
-
-    axiosMock.resetHistory();
 
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      startQtr: "20222",
-      endQtr: "20222",
+      quarter: "20232",
       buildingCode: "GIRV",
+      classroom: "",
     });
 
-    expect(screen.getByText("CHEM 184")).toBeInTheDocument();
+    expect(screen.getByText("1004")).toBeInTheDocument();
   });
 
   test("calls UCSB Course over time search api correctly with correctly sorted data", async () => {
     axiosMock
-      .onGet("/api/public/courseovertime/buildingsearch")
+      .onGet("/api/public/courseovertime/buildingsearch/classrooms")
       .reply(200, coursesInLibDifferentDate);
 
     const spy = jest.spyOn(
@@ -110,15 +108,13 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    userEvent.selectOptions(selectStartQuarter, "20201");
-    const selectEndQuarter = screen.getByLabelText("End Quarter");
-    userEvent.selectOptions(selectEndQuarter, "20222");
+    const selectQuarter = screen.getByLabelText("Quarter");
+    userEvent.selectOptions(selectQuarter, "20232");
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
     );
 
     userEvent.selectOptions(selectBuilding, "GIRV");
@@ -134,12 +130,12 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      startQtr: "20201",
-      endQtr: "20222",
+      quarter: "20232",
       buildingCode: "GIRV",
+      classroom: "",
     });
 
-    expect(screen.getByText("CHEM 184")).toBeInTheDocument();
+    expect(screen.getByText("1004")).toBeInTheDocument();
 
     // Check that CoursesOverTimeBuildings received the sorted sections data
     const sortedSections = coursesInLibDifferentDate.sort((a, b) =>

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
@@ -65,9 +65,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     userEvent.selectOptions(selectBuilding, "GIRV");
 
@@ -117,9 +115,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
+    await screen.findByTestId(expectedKey);
 
     userEvent.selectOptions(selectBuilding, "GIRV");
 

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
@@ -49,7 +49,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
 
   test("calls UCSB Course over time search api correctly with correct response", async () => {
     axiosMock
-      .onGet("/api/public/courseovertime/buildingsearch/classrooms")
+      .onGet("/api/public/courseovertime/buildingsearch")
       .reply(200, coursesInLib);
 
     render(
@@ -82,9 +82,9 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      quarter: "20222",
+      startQtr: "20222",
+      endQtr: "20222",
       buildingCode: "GIRV",
-      classroom: "",
     });
 
     expect(
@@ -94,7 +94,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
 
   test("calls UCSB Course over time search api correctly with correctly sorted data", async () => {
     axiosMock
-      .onGet("/api/public/courseovertime/buildingsearch/classrooms")
+      .onGet("/api/public/courseovertime/buildingsearch")
       .reply(200, coursesInLibDifferentDate);
 
     const spy = jest.spyOn(
@@ -130,9 +130,9 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      quarter: "20222",
+      startQtr: "20222",
+      endQtr: "20222",
       buildingCode: "GIRV",
-      classroom: "",
     });
 
     expect(

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.test.js
@@ -61,7 +61,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
-    userEvent.selectOptions(selectQuarter, "20232");
+    userEvent.selectOptions(selectQuarter, "20222");
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
@@ -82,12 +82,14 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      quarter: "20232",
+      quarter: "20222",
       buildingCode: "GIRV",
       classroom: "",
     });
 
-    expect(screen.getByText("1004")).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("184")),
+    ).toBeInTheDocument();
   });
 
   test("calls UCSB Course over time search api correctly with correctly sorted data", async () => {
@@ -109,7 +111,7 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
-    userEvent.selectOptions(selectQuarter, "20232");
+    userEvent.selectOptions(selectQuarter, "20222");
     const selectBuilding = screen.getByLabelText("Building Name");
 
     const expectedKey = "CourseOverTimeBuildingsSearch.BuildingCode-option-0";
@@ -130,12 +132,14 @@ describe("CourseOverTimeBuildingsIndexPage tests", () => {
     });
 
     expect(axiosMock.history.get[0].params).toEqual({
-      quarter: "20232",
+      quarter: "20222",
       buildingCode: "GIRV",
       classroom: "",
     });
 
-    expect(screen.getByText("1004")).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("184")),
+    ).toBeInTheDocument();
 
     // Check that CoursesOverTimeBuildings received the sorted sections data
     const sortedSections = coursesInLibDifferentDate.sort((a, b) =>

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -22,13 +22,11 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   List<ConvertedSection> findByQuarterRangeAndInstructor(
       String startQuarter, String endQuarter, String instructor, String functionCode);
 
-  // old
   @Query(
       "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
 
-  // new
   @Query(
       "{'courseInfo.quarter': { $eq: ?0 }, 'section.timeLocations.building': { $regex: ?1, $options: 'i' } }")
   List<ConvertedSection> findByQuarterAndBuildingCode(String quarter, String buildingCode);

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -26,7 +26,6 @@ public class CourseOverTimeBuildingController {
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;
 
-  // old
   @Operation(summary = "Get a list of courses over time, filtered by (abbreviated) building code")
   @GetMapping(value = "/buildingsearch", produces = "application/json")
   public ResponseEntity<String> search(
@@ -62,7 +61,6 @@ public class CourseOverTimeBuildingController {
     return ResponseEntity.ok().body(body);
   }
 
-  // new
   @Operation(
       summary =
           "Get a list of classroom numbers within a particular building, given a quarter and building code")

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -2,7 +2,7 @@ spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
-app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
 
 spring.data.mongodb.uri=${MONGO_URL:${env.MONGO_URL:mongodb://localhost:27017/courses}}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -242,7 +242,6 @@ public class CourseOverTimeBuildingControllerTests {
     assertEquals(expected, actual);
   }
 
-  // old test
   @Test
   public void test_old_endpoint_returns_course_sections() throws Exception {
     CourseInfo info =


### PR DESCRIPTION
Closes #19 

Dokku: https://courses-dev-evaniacheng.dokku-02.cs.ucsb.edu/

In this PR, I changed the frontend to accommodate the new API endpoint and I returned availableClassrooms. You can test it in the dokku deployment. Some building + quarter combinations don't have availableClassrooms so check a few different combinations. 

<img width="1173" alt="Screenshot 2025-05-18 at 11 22 16 PM" src="https://github.com/user-attachments/assets/7772073c-2aa9-49d8-aab2-aaa7b898471d" />
<img width="1154" alt="Screenshot 2025-05-18 at 11 22 26 PM" src="https://github.com/user-attachments/assets/6a5905b5-64c5-4e37-9d73-18a3906488d7" />
<img width="1159" alt="Screenshot 2025-05-18 at 11 23 19 PM" src="https://github.com/user-attachments/assets/e38ba47e-4079-4cb9-9d27-3f5183a040a6" />
Based on the dropdown quarter or buildingCode you choose, there will be a different list of availableClassrooms shown. When you click submit, the classrooms for each quarter would show like it did before. 