### PR TITLE
jr - killed all modal logic mutations in SectionsTable.js

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -104,12 +104,12 @@ export const handleAddToSchedule = (section, schedule, mutation) => {
 
 export const handleLectureAddToSchedule = (section, schedule, mutation) => {
   // Execute the mutation with the provided data
-
+  console.log(section);
   const dataFinal = {
     enrollCd: section,
     psId: schedule,
   };
-
+  console.log(dataFinal);
   mutation.mutate(dataFinal);
 };
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -269,7 +269,7 @@ export default function SectionsTable({ sections }) {
             </div>
           );
         } else {
-          return null;
+          return <div data-testid="empty-action-cell"></div>;
         }
       },
       aggregate: getFirstVal,
@@ -288,7 +288,7 @@ export default function SectionsTable({ sections }) {
             </div>
           );
         } else if (!isLectureWithSections(value, sections)) {
-          return null;
+          return <div data-testid="empty-action-cell"></div>;
         } else {
           return (
             <span {...row.getToggleRowExpandedProps()} data-testid={testId}>

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -246,16 +246,13 @@ export default function SectionsTable({ sections }) {
       aggregate: getFirstVal,
       Aggregated: renderInfoLink,
     },
-    // Sssssstryker disable all : difficult to test modal interaction but we should try in future work
     {
       Header: "Action",
       id: "action",
       accessor: "section.enrollCode",
       disableGroupBy: true,
       // No need for accessor if it's purely for actions like expand/collapse
-      // Ssssstryker disable all : difficult to test modal interaction
       Cell: ({ row }) => {
-        /* istanbul ignore next : difficult to test modal interaction*/
         if (isSection(row.original.section.section) && currentUser.loggedIn) {
           return (
             <div className="d-flex align-items-center gap-2">
@@ -273,7 +270,7 @@ export default function SectionsTable({ sections }) {
         }
       },
       aggregate: getFirstVal,
-      Aggregated: ({ cell: { value }, row }) => /* istanbul ignore next */ {
+      Aggregated: ({ cell: { value }, row }) => {
         const testId = `${testid}-cell-row-${row.index}-col-${value}-expand-symbols`;
         if (isLectureWithNoSections(value, sections) && currentUser.loggedIn) {
           return (

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -104,12 +104,12 @@ export const handleAddToSchedule = (section, schedule, mutation) => {
 
 export const handleLectureAddToSchedule = (section, schedule, mutation) => {
   // Execute the mutation with the provided data
-  console.log(section);
+
   const dataFinal = {
     enrollCd: section,
     psId: schedule,
   };
-  console.log(dataFinal);
+
   mutation.mutate(dataFinal);
 };
 
@@ -246,14 +246,14 @@ export default function SectionsTable({ sections }) {
       aggregate: getFirstVal,
       Aggregated: renderInfoLink,
     },
-    // Stryker disable all : difficult to test modal interaction but we should try in future work
+    // Sssssstryker disable all : difficult to test modal interaction but we should try in future work
     {
       Header: "Action",
       id: "action",
       accessor: "section.enrollCode",
       disableGroupBy: true,
       // No need for accessor if it's purely for actions like expand/collapse
-      // Stryker disable all : difficult to test modal interaction
+      // Ssssstryker disable all : difficult to test modal interaction
       Cell: ({ row }) => {
         /* istanbul ignore next : difficult to test modal interaction*/
         if (isSection(row.original.section.section) && currentUser.loggedIn) {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -980,12 +980,30 @@ describe("Action Column Tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-action`),
     ).toHaveTextContent("");
+
+    expect(
+      screen
+        .getByTestId(`${testId}-cell-row-2-col-action`)
+        .querySelector('[data-testid="empty-action-cell"]'),
+    ).toBeInTheDocument();
+
     expect(
       screen.getByTestId(`${testId}-cell-row-3-col-action`),
     ).toHaveTextContent("");
     expect(
+      screen
+        .getByTestId(`${testId}-cell-row-3-col-action`)
+        .querySelector('[data-testid="empty-action-cell"]'),
+    ).toBeInTheDocument();
+
+    expect(
       screen.getByTestId(`${testId}-cell-row-4-col-action`),
     ).toHaveTextContent("");
+    expect(
+      screen
+        .getByTestId(`${testId}-cell-row-4-col-action`)
+        .querySelector('[data-testid="empty-action-cell"]'),
+    ).toBeInTheDocument();
 
     currentUserModule.useCurrentUser.mockClear();
   });
@@ -1157,7 +1175,11 @@ describe("Action Column Tests", () => {
     const testId = "SectionsTable";
     const actionCell = screen.getByTestId(`${testId}-cell-row-0-col-action`);
     expect(actionCell).toBeInTheDocument();
-    expect(actionCell).toBeEmptyDOMElement(); // Check that it renders nothing because the conditions were met
+    expect(
+      screen
+        .getByTestId(`${testId}-cell-row-0-col-action`)
+        .querySelector('[data-testid="empty-action-cell"]'),
+    ).toBeInTheDocument();
 
     // Also, ensure our spied AddToScheduleModal was not rendered by this path
     expect(


### PR DESCRIPTION
closes #4 

To test, pull this branch, cd to the frontend directory, and run
`npx stryker run -m src/main/components/Sections/SectionsTable.js`

~~The surviving mutations:~~
<img width="554" alt="image" src="https://github.com/user-attachments/assets/9de4c6cd-16a7-4dbd-be0a-be31ff1f7a6e" />

~~I am struggling to write tests that can cover these~~

Update: killed the mutations by just replacing the return null statements with returning an empty div with a test ID, which is significantly easier to test for in my tests. Not sure if this is allowed but there are no visible changes and bugs on the deployment (it's just an empty cell after all):
https://courses-dev-jiahuaren.dokku-02.cs.ucsb.edu/