### PR TITLE
mc - Add an API Endpoint to Retrieve the List of GE Areas

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -3,8 +3,8 @@ package edu.ucsb.cs156.courses.controllers;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,9 +50,9 @@ public class UCSBCurriculumController extends ApiController {
   @GetMapping(value = "/generalEducationInfo", produces = "application/json")
   public ResponseEntity<?> generalEducationInfo(
       @Parameter(description = "Enter either L&S, ENGR, or CRST")
-      @RequestParam(value = "collegeCode", required = false)
-      String collegeCode
-  ) throws Exception {
+          @RequestParam(value = "collegeCode", required = false)
+          String collegeCode)
+      throws Exception {
 
     if (collegeCode != null) {
       // returns List<String> of requirementCode

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -4,6 +4,8 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -42,5 +44,24 @@ public class UCSBCurriculumController extends ApiController {
     String body = ucsbCurriculumService.getFinalsInfo(quarterYYYYQ, enrollCd);
 
     return ResponseEntity.ok().body(body);
+  }
+
+  @Operation(summary = "Get General Education areas, optionally filtered by collegeCode")
+  @GetMapping(value = "/generalEducationInfo", produces = "application/json")
+  public ResponseEntity<?> generalEducationInfo(
+      @Parameter(description = "Enter either L&S, ENGR, or CRST")
+      @RequestParam(value = "collegeCode", required = false)
+      String collegeCode
+  ) throws Exception {
+
+    if (collegeCode != null) {
+      // returns List<String> of requirementCode
+      List<String> codes = ucsbCurriculumService.getRequirementCodesByCollege(collegeCode);
+      return ResponseEntity.ok().body(codes);
+    } else {
+      // returns the full raw JSON array
+      String body = ucsbCurriculumService.getGeneralEducationInfo();
+      return ResponseEntity.ok().body(body);
+    }
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/GERequirement.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/GERequirement.java
@@ -1,0 +1,28 @@
+package edu.ucsb.cs156.courses.documents;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class GERequirement {
+  @JsonProperty("requirementCode")
+  private String requirementCode;
+
+  @JsonProperty("requirementTranslation")
+  private String requirementTranslation;
+
+  @JsonProperty("collegeCode")
+  private String collegeCode;
+
+  @JsonProperty("objCode")
+  private String objCode;
+
+  @JsonProperty("courseCount")
+  private int courseCount;
+
+  @JsonProperty("units")
+  private int units;
+
+  @JsonProperty("inactive")
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -1,8 +1,7 @@
 package edu.ucsb.cs156.courses.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.GERequirement;
@@ -10,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -294,13 +294,13 @@ public class UCSBCurriculumService {
   public List<String> getRequirementCodesByCollege(String collegeCode) throws Exception {
     String json = getGeneralEducationInfo();
 
-    List<GERequirement> allAreas = objectMapper.readValue(
-          json, new TypeReference<List<GERequirement>>() {});
+    List<GERequirement> allAreas =
+        objectMapper.readValue(json, new TypeReference<List<GERequirement>>() {});
 
     return allAreas.stream()
-          .filter(area -> area.getCollegeCode().equalsIgnoreCase(collegeCode))
-          .map(GERequirement::getRequirementCode)
-          .distinct()
-          .collect(Collectors.toList());
+        .filter(area -> area.getCollegeCode().equalsIgnoreCase(collegeCode))
+        .map(GERequirement::getRequirementCode)
+        .distinct()
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
@@ -21,8 +19,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import java.util.List;
-
 
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
@@ -73,48 +69,44 @@ public class UCSBCurriculumControllerTests extends ControllerTestCase {
     assertEquals(expectedResult, responseString);
   }
 
-  /**
-   * GET /api/public/generalEducationInfo  → raw JSON from service
-   */
+  /** GET /api/public/generalEducationInfo → raw JSON from service */
   @Test
   public void test_generalEducationInfo_noCollegeCode() throws Exception {
     // ← use the real “English Reading & Composition” (all ASCII) instead of “…”
     String expectedJson =
-      "[" +
-        "{\"requirementCode\":\"A1\"," +
-        "\"requirementTranslation\":\"English Reading & Composition\"," +
-        "\"collegeCode\":\"ENGR\"," +
-        "\"objCode\":\"BS\"," +
-        "\"courseCount\":1," +
-        "\"units\":4," +
-        "\"inactive\":false}" +
-      "]";
+        "["
+            + "{\"requirementCode\":\"A1\","
+            + "\"requirementTranslation\":\"English Reading & Composition\","
+            + "\"collegeCode\":\"ENGR\","
+            + "\"objCode\":\"BS\","
+            + "\"courseCount\":1,"
+            + "\"units\":4,"
+            + "\"inactive\":false}"
+            + "]";
 
-    when(ucsbCurriculumService.getGeneralEducationInfo())
-        .thenReturn(expectedJson);
+    when(ucsbCurriculumService.getGeneralEducationInfo()).thenReturn(expectedJson);
 
-    mockMvc.perform(get("/api/public/generalEducationInfo")
-              .contentType("application/json"))
-          .andExpect(status().isOk())
-          .andExpect(content().json(expectedJson));
+    mockMvc
+        .perform(get("/api/public/generalEducationInfo").contentType("application/json"))
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
   }
 
-  /**
-   * GET /api/public/generalEducationInfo?collegeCode=ENGR  → List<String> of codes
-   */
+  /** GET /api/public/generalEducationInfo?collegeCode=ENGR → List<String> of codes */
   @Test
   public void test_generalEducationInfo_withCollegeCode() throws Exception {
     // our controller will call getRequirementCodesByCollege("ENGR")
     List<String> fakeCodes = List.of("A1", "A2");
-    when(ucsbCurriculumService.getRequirementCodesByCollege("ENGR"))
-        .thenReturn(fakeCodes);
+    when(ucsbCurriculumService.getRequirementCodesByCollege("ENGR")).thenReturn(fakeCodes);
 
     MvcResult response =
-      mockMvc.perform(get("/api/public/generalEducationInfo")
-                .param("collegeCode", "ENGR")
-                .contentType("application/json"))
-             .andExpect(status().isOk())
-             .andReturn();
+        mockMvc
+            .perform(
+                get("/api/public/generalEducationInfo")
+                    .param("collegeCode", "ENGR")
+                    .contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     String body = response.getResponse().getContentAsString();
     // JSON representation of ["A1","A2"]

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -3,8 +3,8 @@ package edu.ucsb.cs156.courses.controllers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -322,15 +322,16 @@ public class UCSBCurriculumServiceTests {
   @Test
   public void test_getGeneralEducationInfo_success() throws Exception {
     // a minimal valid JSON array
-    String expectedResult = "[" +
-        "{\"requirementCode\":\"A1\"," +
-         "\"requirementTranslation\":\"English Reading & Composition\"," +
-         "\"collegeCode\":\"ENGR\"," +
-         "\"objCode\":\"BS\"," +
-         "\"courseCount\":1," +
-         "\"units\":4," +
-         "\"inactive\":false}" +
-      "]";
+    String expectedResult =
+        "["
+            + "{\"requirementCode\":\"A1\","
+            + "\"requirementTranslation\":\"English Reading & Composition\","
+            + "\"collegeCode\":\"ENGR\","
+            + "\"objCode\":\"BS\","
+            + "\"courseCount\":1,"
+            + "\"units\":4,"
+            + "\"inactive\":false}"
+            + "]";
 
     // stub out the GET to the GE endpoint
     this.mockRestServiceServer
@@ -348,12 +349,13 @@ public class UCSBCurriculumServiceTests {
   @Test
   public void test_getRequirementCodesByCollege_filtersAndDistinct() throws Exception {
     // JSON containing mixed collegeCodes, with a duplicate A1
-    String fakeJson = "[" +
-      "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
-      "{\"requirementCode\":\"B1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"L&S\",\"objCode\":\"BA\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
-      "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
-      "{\"requirementCode\":\"A2\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}" +
-    "]";
+    String fakeJson =
+        "["
+            + "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false},"
+            + "{\"requirementCode\":\"B1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"L&S\",\"objCode\":\"BA\",\"courseCount\":1,\"units\":4,\"inactive\":false},"
+            + "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false},"
+            + "{\"requirementCode\":\"A2\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}"
+            + "]";
 
     // stub the same GE endpoint
     this.mockRestServiceServer
@@ -368,5 +370,4 @@ public class UCSBCurriculumServiceTests {
     List<String> codes = ucs.getRequirementCodesByCollege("ENGR");
     assertEquals(List.of("A1", "A2"), codes);
   }
-
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -318,4 +318,55 @@ public class UCSBCurriculumServiceTests {
 
     assertEquals(expectedResult, result);
   }
+
+  @Test
+  public void test_getGeneralEducationInfo_success() throws Exception {
+    // a minimal valid JSON array
+    String expectedResult = "[" +
+        "{\"requirementCode\":\"A1\"," +
+         "\"requirementTranslation\":\"English Reading & Composition\"," +
+         "\"collegeCode\":\"ENGR\"," +
+         "\"objCode\":\"BS\"," +
+         "\"courseCount\":1," +
+         "\"units\":4," +
+         "\"inactive\":false}" +
+      "]";
+
+    // stub out the GET to the GE endpoint
+    this.mockRestServiceServer
+        .expect(requestTo(UCSBCurriculumService.GE_ENDPOINT))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    String result = ucs.getGeneralEducationInfo();
+    assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void test_getRequirementCodesByCollege_filtersAndDistinct() throws Exception {
+    // JSON containing mixed collegeCodes, with a duplicate A1
+    String fakeJson = "[" +
+      "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
+      "{\"requirementCode\":\"B1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"L&S\",\"objCode\":\"BA\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
+      "{\"requirementCode\":\"A1\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}," +
+      "{\"requirementCode\":\"A2\",\"requirementTranslation\":\"…\",\"collegeCode\":\"ENGR\",\"objCode\":\"BS\",\"courseCount\":1,\"units\":4,\"inactive\":false}" +
+    "]";
+
+    // stub the same GE endpoint
+    this.mockRestServiceServer
+        .expect(requestTo(UCSBCurriculumService.GE_ENDPOINT))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(fakeJson, MediaType.APPLICATION_JSON));
+
+    // invoke the filter
+    List<String> codes = ucs.getRequirementCodesByCollege("ENGR");
+    assertEquals(List.of("A1", "A2"), codes);
+  }
+
 }


### PR DESCRIPTION
close #8 
In this PR, I add an API Endpoint to Retrieve the List of GE Areas
*Not hard code this time!*
Dokku deployment link: https://courses-dev-mujiaaa.dokku-02.cs.ucsb.edu/

If you leave the collegeCode blank, it will return every GE Area:
<img width="1440" alt="Screenshot 2025-05-20 at 1 13 25 PM" src="https://github.com/user-attachments/assets/d7cfc389-4dc2-4557-bfe7-8f7208b4dc78" />
<img width="1440" alt="Screenshot 2025-05-20 at 1 13 40 PM" src="https://github.com/user-attachments/assets/0b95f029-c1c9-439f-bc26-0d93b569d151" />

If you put L&S in the collegeCode, it will return GE Area for L&S:
<img width="1440" alt="Screenshot 2025-05-20 at 1 14 00 PM" src="https://github.com/user-attachments/assets/fa501724-a78b-49f2-aaf8-8333be5faf2e" />
<img width="1440" alt="Screenshot 2025-05-20 at 1 14 10 PM" src="https://github.com/user-attachments/assets/296a2b51-f25a-4419-8954-6faf6c720161" />

If you put ENGR in the collegeCode, it will return GE Area for ENGR:
<img width="1311" alt="Screenshot 2025-05-20 at 2 09 54 PM" src="https://github.com/user-attachments/assets/b72e00d0-a9b0-41cf-96f9-d2b3a2f1d092" />
<img width="1311" alt="Screenshot 2025-05-20 at 2 10 10 PM" src="https://github.com/user-attachments/assets/f140b9be-60db-4b2e-99ad-cb2dc0fea6f2" />

Note that the GE Area outputted for ENGR is different from the area we know. This is mainly the problem in the database. Once the database is fixed, it will return the correct value. 
