### PR TITLE
sw - UX IMPROVEMENT: Make width of pagination component consistent.

### DIFF
--- a/frontend/src/main/components/Utils/OurPagination.js
+++ b/frontend/src/main/components/Utils/OurPagination.js
@@ -6,7 +6,6 @@ export const emptyArray = () => []; // factored out for Stryker testing
 const OurPagination = ({
   updateActivePage,
   totalPages = 10,
-  maxPages = 8,
   testId = "OurPagination",
 }) => {
   const [activePage, setActivePage] = useState(1);
@@ -44,30 +43,18 @@ const OurPagination = ({
     return paginationItems;
   };
 
-  const generatePaginationItemsWithEllipsis = () => {
+  const generateComplexPaginationItems = () => {
     const paginationItems = emptyArray();
 
-    const leftEllipsis = activePage > 3;
-    const rightEllipsis = activePage < totalPages - 2;
-
+    // Always show page 1 and totalPages
     paginationItems.push(pageButton(1));
-    if (leftEllipsis) {
-      paginationItems.push(
-        <Pagination.Ellipsis
-          key="left-ellipsis"
-          data-testid={`${testId}-left-ellipsis`}
-        />,
-      );
-    }
-    // Show a range of pages around the active page
-    let start = Math.max(activePage - 1, 2);
-    let end = Math.min(activePage + 1, totalPages - 1);
 
-    for (let number = start; number <= end; number++) {
-      paginationItems.push(pageButton(number));
-    }
-
-    if (rightEllipsis) {
+    // Case 1: activePage is near the beginning (1, 2, 3, 4)
+    if (activePage < 5) {
+      paginationItems.push(pageButton(2));
+      paginationItems.push(pageButton(3));
+      paginationItems.push(pageButton(4));
+      paginationItems.push(pageButton(5));
       paginationItems.push(
         <Pagination.Ellipsis
           key="right-ellipsis"
@@ -75,15 +62,46 @@ const OurPagination = ({
         />,
       );
     }
-    paginationItems.push(pageButton(totalPages));
+    // Case 2: activePage is near the end (totalPages - 3, totalPages - 2, totalPages - 1, totalPages)
+    else if (activePage > totalPages - 4) {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="left-ellipsis"
+          data-testid={`${testId}-left-ellipsis`}
+        />,
+      );
+      paginationItems.push(pageButton(totalPages - 4));
+      paginationItems.push(pageButton(totalPages - 3));
+      paginationItems.push(pageButton(totalPages - 2));
+      paginationItems.push(pageButton(totalPages - 1));
+    }
+    // Case 3: activePage is in the middle
+    else {
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="left-ellipsis"
+          data-testid={`${testId}-left-ellipsis`}
+        />,
+      );
+      paginationItems.push(pageButton(activePage - 1));
+      paginationItems.push(pageButton(activePage));
+      paginationItems.push(pageButton(activePage + 1));
+      paginationItems.push(
+        <Pagination.Ellipsis
+          key="right-ellipsis"
+          data-testid={`${testId}-right-ellipsis`}
+        />,
+      );
+    }
 
+    paginationItems.push(pageButton(totalPages));
     return paginationItems;
   };
 
   const generatePaginationItems = () =>
-    totalPages <= maxPages
+    totalPages <= 7
       ? generateSimplePaginationItems()
-      : generatePaginationItemsWithEllipsis();
+      : generateComplexPaginationItems();
 
   return (
     <Pagination>

--- a/frontend/src/tests/components/Utils/OurPagination.test.js
+++ b/frontend/src/tests/components/Utils/OurPagination.test.js
@@ -15,21 +15,11 @@ describe("OurPagination tests", () => {
     expect(emptyArray()).toStrictEqual([]);
   });
 
-  test("renders the correct text for totalPages 5 maxPages 10", async () => {
-    // Arrange
-
+  test("renders correctly for totalPages = 5 (less than or equal to 7)", async () => {
     const updateActivePage = jest.fn();
-
-    // Act
     render(
-      <OurPagination
-        totalPages={5}
-        maxPages={10}
-        updateActivePage={updateActivePage}
-      />,
+      <OurPagination totalPages={5} updateActivePage={updateActivePage} />,
     );
-
-    // Assert
 
     checkTestIdsInOrder([
       "OurPagination-prev",
@@ -42,15 +32,12 @@ describe("OurPagination tests", () => {
     ]);
   });
 
-  test("renders the correct text for totalPages 10 maxPages 10", async () => {
-    // Arrange
-
+  test("renders correctly for totalPages = 7 (less than or equal to 7)", async () => {
     const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={7} updateActivePage={updateActivePage} />,
+    );
 
-    // Act
-    render(<OurPagination maxPages={10} updateActivePage={updateActivePage} />);
-
-    // Assert
     checkTestIdsInOrder([
       "OurPagination-prev",
       "OurPagination-1",
@@ -60,177 +47,252 @@ describe("OurPagination tests", () => {
       "OurPagination-5",
       "OurPagination-6",
       "OurPagination-7",
-      "OurPagination-8",
-      "OurPagination-9",
-      "OurPagination-10",
       "OurPagination-next",
     ]);
   });
 
-  test("renders the correct text for totalPages 12 maxPages 5", async () => {
-    // Arrange
-
+  test("renders correctly for totalPages = 12 (greater than 7), initial state (activePage=1)", async () => {
     const updateActivePage = jest.fn();
-
-    // Act
     render(
-      <OurPagination
-        totalPages={12}
-        maxPages={5}
-        updateActivePage={updateActivePage}
-      />,
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
     );
-
-    // Assert
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-2",
-      "OurPagination-right-ellipsis",
-      "OurPagination-12",
-      "OurPagination-next",
-    ]);
-
-    const nextButton = screen.getByTestId("OurPagination-next");
-    fireEvent.click(nextButton);
-
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-2",
-      "OurPagination-3",
-      "OurPagination-right-ellipsis",
-      "OurPagination-12",
-      "OurPagination-next",
-    ]);
-
-    fireEvent.click(nextButton);
-
+    // Expected: 1, 2, 3, 4, 5, ..., 12
     checkTestIdsInOrder([
       "OurPagination-prev",
       "OurPagination-1",
       "OurPagination-2",
       "OurPagination-3",
       "OurPagination-4",
+      "OurPagination-5",
       "OurPagination-right-ellipsis",
       "OurPagination-12",
       "OurPagination-next",
     ]);
+  });
 
-    fireEvent.click(nextButton);
+  test("renders correctly for totalPages = 12, activePage = 4", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+
+    // Click to page 4
+    fireEvent.click(screen.getByTestId("OurPagination-4"));
+
+    // Expected: 1, 2, 3, 4, 5, ..., 12 (activePage < 5)
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-2",
+      "OurPagination-3",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 5 (middle range)", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
+    // Expected: 1, ..., 4, 5, 6, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 8 (middle range, next clicks)", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+
+    const nextButton = screen.getByTestId("OurPagination-next");
+    fireEvent.click(nextButton); // page 2
+    fireEvent.click(nextButton); // page 3
+    fireEvent.click(nextButton); // page 4
+    fireEvent.click(nextButton); // page 5
+    // Expected: 1, ..., 4, 5, 6, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 6
+    // Expected: 1, ..., 5, 6, 7, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 7
+    // Expected: 1, ..., 6, 7, 8, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-6",
+      "OurPagination-7",
+      "OurPagination-8",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+    fireEvent.click(nextButton); // page 8
+    // Expected: 1, ..., 7, 8, 9, ..., 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-7",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 9 (near end)", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+    // Click to page 9 (totalPages - 3)
+    // This requires multiple clicks on next or direct jump if available.
+    // For simplicity, we'll simulate state by clicking next multiple times
+    for (let i = 0; i < 8; i++) {
+      // 1 -> 2 -> ... -> 9
+      fireEvent.click(screen.getByTestId("OurPagination-next"));
+    }
+    // Expected: 1, ..., 8, 9, 10, 11, 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-11",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("renders correctly for totalPages = 12, activePage = 12 (end)", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+    fireEvent.click(screen.getByTestId("OurPagination-12"));
+    // Expected: 1, ..., 8, 9, 10, 11, 12
+    checkTestIdsInOrder([
+      "OurPagination-prev",
+      "OurPagination-1",
+      "OurPagination-left-ellipsis",
+      "OurPagination-8",
+      "OurPagination-9",
+      "OurPagination-10",
+      "OurPagination-11",
+      "OurPagination-12",
+      "OurPagination-next",
+    ]);
+  });
+
+  test("navigation: prev button works correctly", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
+    );
+    // Go to page 5
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
+    expect(screen.getByTestId("OurPagination-5").parentElement).toHaveClass(
+      "active",
+    );
 
     checkTestIdsInOrder([
       "OurPagination-prev",
       "OurPagination-1",
       "OurPagination-left-ellipsis",
-      "OurPagination-3",
       "OurPagination-4",
       "OurPagination-5",
+      "OurPagination-6",
       "OurPagination-right-ellipsis",
       "OurPagination-12",
       "OurPagination-next",
     ]);
 
     const prevButton = screen.getByTestId("OurPagination-prev");
-    fireEvent.click(prevButton);
+    fireEvent.click(prevButton); // Go to page 4
 
+    // Assert that page 4 is now active
+    expect(screen.getByTestId("OurPagination-4").parentElement).toHaveClass(
+      "active",
+    );
+    expect(screen.getByTestId("OurPagination-5").parentElement).not.toHaveClass(
+      "active",
+    );
+
+    // Expected: 1, 2, 3, 4, 5, ..., 12
     checkTestIdsInOrder([
       "OurPagination-prev",
       "OurPagination-1",
       "OurPagination-2",
       "OurPagination-3",
       "OurPagination-4",
-      "OurPagination-right-ellipsis",
-      "OurPagination-12",
-      "OurPagination-next",
-    ]);
-
-    const button1 = screen.getByTestId("OurPagination-1");
-    fireEvent.click(button1);
-
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-2",
-      "OurPagination-right-ellipsis",
-      "OurPagination-12",
-      "OurPagination-next",
-    ]);
-
-    const button12 = screen.getByTestId("OurPagination-12");
-    fireEvent.click(button12);
-
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-left-ellipsis",
-      "OurPagination-11",
-      "OurPagination-12",
-      "OurPagination-next",
-    ]);
-
-    fireEvent.click(prevButton);
-    fireEvent.click(prevButton);
-    fireEvent.click(prevButton);
-
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-left-ellipsis",
-      "OurPagination-8",
-      "OurPagination-9",
-      "OurPagination-10",
+      "OurPagination-5",
       "OurPagination-right-ellipsis",
       "OurPagination-12",
       "OurPagination-next",
     ]);
   });
 
-  test("renders the correct text for totalPages 5 maxPages 2", async () => {
-    // Arrange
-
+  test("navigation: clicking page 1 from a middle page", async () => {
     const updateActivePage = jest.fn();
-
-    // Act
     render(
-      <OurPagination
-        totalPages={5}
-        maxPages={3}
-        updateActivePage={updateActivePage}
-      />,
+      <OurPagination totalPages={12} updateActivePage={updateActivePage} />,
     );
-
-    // Assert
-
+    // Go to page 5
+    fireEvent.click(screen.getByTestId("OurPagination-5"));
     checkTestIdsInOrder([
+      // Page 5
       "OurPagination-prev",
       "OurPagination-1",
-      "OurPagination-2",
-      "OurPagination-right-ellipsis",
+      "OurPagination-left-ellipsis",
+      "OurPagination-4",
       "OurPagination-5",
+      "OurPagination-6",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
       "OurPagination-next",
     ]);
 
-    const button1 = screen.getByTestId("OurPagination-1");
-    expect(button1.parentElement).toHaveClass("active");
-    const button2 = screen.getByTestId("OurPagination-2");
-    expect(button2.parentElement).not.toHaveClass("active");
-
-    const nextButton = screen.getByTestId("OurPagination-next");
-    fireEvent.click(nextButton);
-
-    checkTestIdsInOrder([
-      "OurPagination-prev",
-      "OurPagination-1",
-      "OurPagination-2",
-      "OurPagination-3",
-      "OurPagination-right-ellipsis",
-      "OurPagination-5",
-      "OurPagination-next",
-    ]);
-
-    fireEvent.click(nextButton);
-
+    fireEvent.click(screen.getByTestId("OurPagination-1"));
+    // Expected: 1, 2, 3, 4, 5, ..., 12
     checkTestIdsInOrder([
       "OurPagination-prev",
       "OurPagination-1",
@@ -238,9 +300,34 @@ describe("OurPagination tests", () => {
       "OurPagination-3",
       "OurPagination-4",
       "OurPagination-5",
+      "OurPagination-right-ellipsis",
+      "OurPagination-12",
       "OurPagination-next",
     ]);
+  });
 
-    fireEvent.click(nextButton);
+  test("checks active class on buttons", async () => {
+    const updateActivePage = jest.fn();
+    render(
+      <OurPagination totalPages={5} updateActivePage={updateActivePage} />,
+    );
+
+    // Initial state: page 1 is active
+    expect(screen.getByTestId("OurPagination-1").parentElement).toHaveClass(
+      "active",
+    );
+    expect(screen.getByTestId("OurPagination-2").parentElement).not.toHaveClass(
+      "active",
+    );
+
+    fireEvent.click(screen.getByTestId("OurPagination-next")); // page 2
+
+    // After re-render: page 2 should be active. Re-query elements.
+    expect(screen.getByTestId("OurPagination-1").parentElement).not.toHaveClass(
+      "active",
+    );
+    expect(screen.getByTestId("OurPagination-2").parentElement).toHaveClass(
+      "active",
+    );
   });
 });


### PR DESCRIPTION
Closed #3 
Refactors the OurPagination component to consistently display a fixed number of
page elements (7 items: Prev, 5 page/ellipsis slots, Next) when totalPages
exceeds 7. If totalPages is 7 or less, all pages are shown. This addresses
an issue where the component's width would change dynamically.

The `maxPages` prop has been removed as the component now manages its
display width internally based on the new 7-item target.
![PixPin_2025-05-20_18-30-18](https://github.com/user-attachments/assets/0cc531dd-2d01-4f14-a0b2-6ad5a372f213)

Updated tests in OurPagination.test.js to:
- Remove references to the `maxPages` prop.
- Verify the new fixed-width rendering logic across various scenarios,
  including different total page counts and active page positions.
- Ensure correct active class assignment on page buttons, especially
  after 'Prev' and 'Next' actions, to prevent stale element references
  and accurately kill mutation test survivors.
  
  Dokku:
  https://courses-dev-andrew200356.dokku-02.cs.ucsb.edu